### PR TITLE
Añadir la capa de API

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -12,7 +12,7 @@ on:
 
 env:
 
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.20"
 
 jobs:
 

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -1,21 +1,91 @@
 package main
 
 import (
+	services "vidya-sale/api/service"
+
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/logger"
 )
 
 func main() {
 	app := fiber.New()
+	api := app.Group("/api", logger.New())
+	listenPort := ":8080"
 
-	api := app.Group("/api")
+	managerService, serviceError :=
+		services.NewOfferManagerService(services.WithMemoryProductRepository())
 
-	api.Get("/hello", func(context *fiber.Ctx) error {
-		return context.SendString("Hello, World!")
+	if serviceError != nil {
+		panic(serviceError)
+	}
+
+	processorService := services.NewMessageProcessorService()
+
+	api.Get("/offers/:gameName", func(context *fiber.Ctx) error {
+		return getGameOffers(context, managerService)
+	})
+	api.Post("/offers", func(context *fiber.Ctx) error {
+		return storeOffer(context, managerService, processorService)
 	})
 
-	apiError := app.Listen(":3000")
+	app.Listen(listenPort)
+}
 
-	if apiError != nil {
-		panic(apiError)
+func getGameOffers(context *fiber.Ctx, offerManager *services.OfferManagerService) error {
+	gameName := context.Params("gameName")
+
+	gameOffers, getGameOffersError := offerManager.GetGameOffers(gameName)
+
+	if getGameOffersError != nil {
+		return context.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"success": false,
+			"message": "Could not find offers for the related game.",
+		})
 	}
+
+	return context.Status(fiber.StatusOK).JSON(fiber.Map{
+		"success": true,
+		"message": "Game offers successfully retrieved.",
+		"data":    gameOffers,
+	})
+}
+
+func storeOffer(context *fiber.Ctx, offerManager *services.OfferManagerService,
+	processorService *services.MessageProcessorService) error {
+
+	messageRequest := &MessageRequest{}
+
+	if parseError := context.BodyParser(messageRequest); parseError != nil {
+		return context.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"success": false,
+			"message": "Could not parse request body.",
+		})
+	}
+
+	gameName, platform, link, price := processorService.ParseMessage(messageRequest.Message)
+
+	storingError := offerManager.StoreOffer(gameName, platform, link, price)
+
+	if storingError != nil {
+		return context.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"success": false,
+			"message": "Could not find the elements correctly.",
+			"data": fiber.Map{
+				"incomingMessage": messageRequest.Message,
+				"gameName":        gameName,
+				"platform":        platform,
+				"link":            link,
+				"price":           price,
+			},
+		})
+	}
+
+	return context.Status(fiber.StatusOK).JSON(fiber.Map{
+		"success": true,
+		"message": "Offer successfully stored.",
+	})
+}
+
+type MessageRequest struct {
+	Message string `json:"message"`
 }

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/url"
 	services "vidya-sale/api/service"
 
 	"github.com/gofiber/fiber/v2"
@@ -32,7 +33,7 @@ func main() {
 }
 
 func getGameOffers(context *fiber.Ctx, offerManager *services.OfferManagerService) error {
-	gameName := context.Params("gameName")
+	gameName, _ := url.QueryUnescape(context.Params("gameName"))
 
 	gameOffers, getGameOffersError := offerManager.GetGameOffers(gameName)
 
@@ -67,7 +68,7 @@ func storeOffer(context *fiber.Ctx, offerManager *services.OfferManagerService,
 	storingError := offerManager.StoreOffer(gameName, platform, link, price)
 
 	if storingError != nil {
-		return context.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+		return context.Status(fiber.StatusUnprocessableEntity).JSON(fiber.Map{
 			"success": false,
 			"message": "Could not find the elements correctly.",
 			"data": fiber.Map{

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -44,10 +44,25 @@ func getGameOffers(context *fiber.Ctx, offerManager *services.OfferManagerServic
 		})
 	}
 
+	offersResponse := []PlatformResponse{}
+	for platform, offers := range gameOffers {
+		platformOffers := []OfferResponse{}
+		for _, offer := range offers {
+			platformOffers = append(platformOffers, OfferResponse{
+				Link:  offer.GetLink(),
+				Price: offer.GetPrice(),
+			})
+		}
+		offersResponse = append(offersResponse, PlatformResponse{
+			Platform: platform,
+			Offers:   platformOffers,
+		})
+	}
+
 	return context.Status(fiber.StatusOK).JSON(fiber.Map{
 		"success": true,
 		"message": "Game offers successfully retrieved.",
-		"data":    gameOffers,
+		"data":    offersResponse,
 	})
 }
 
@@ -89,4 +104,14 @@ func storeOffer(context *fiber.Ctx, offerManager *services.OfferManagerService,
 
 type MessageRequest struct {
 	Message string `json:"message"`
+}
+
+type PlatformResponse struct {
+	Platform string          `json:"platform"`
+	Offers   []OfferResponse `json:"offers"`
+}
+
+type OfferResponse struct {
+	Link  string  `json:"link"`
+	Price float64 `json:"price"`
 }

--- a/src/api/api_test.go
+++ b/src/api/api_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	aggregates "vidya-sale/api/aggregate"
+	"vidya-sale/api/domain/product/memory"
+	services "vidya-sale/api/service"
+	valueobjects "vidya-sale/api/valueobject"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOffersRoute(t *testing.T) {
+	app := fiber.New()
+	existingProduct, _ := aggregates.NewProduct("Red Dead Redemption", "Switch")
+	existingOffer, _ := valueobjects.NewOffer("Test Link", 44.99)
+	existingProduct.AddOffer(existingOffer)
+	productRepository := memory.New()
+	productRepository.Add(existingProduct)
+	offerManager, _ := services.NewOfferManagerService(services.WithProductRepository(productRepository))
+
+	app.Get("/api/offers/:gameName", func(context *fiber.Ctx) error {
+		return getGameOffers(context, offerManager)
+	})
+
+	testCases := []struct {
+		name         string
+		route        string
+		expectedCode int
+	}{
+		{
+			name:         "Get HTTP status 200 when offers exist",
+			route:        "/api/offers/" + url.QueryEscape(existingProduct.GetName()),
+			expectedCode: fiber.StatusOK,
+		},
+		{
+			name:         "Get HTTP status 404 when offers do not exist",
+			route:        "/api/offers/" + url.QueryEscape("Non existing game"),
+			expectedCode: fiber.StatusNotFound,
+		},
+		{
+			name:         "Get HTTP status 404 when route does not exist",
+			route:        "/not-found",
+			expectedCode: fiber.StatusNotFound,
+		},
+	}
+
+	for _, testCase := range testCases {
+		request := httptest.NewRequest("GET", testCase.route, nil)
+
+		response, _ := app.Test(request, 1)
+
+		assert.Equalf(t, testCase.expectedCode, response.StatusCode, testCase.name)
+	}
+}
+
+func TestStoreOfferRoute(t *testing.T) {
+	app := fiber.New()
+	productRepository := memory.New()
+	offerManager, _ := services.NewOfferManagerService(services.WithProductRepository(productRepository))
+	processorService := services.NewMessageProcessorService()
+
+	properMessageBody := struct {
+		Message string `json:"message,omitempty"`
+	}{
+		Message: `📆⬇️ Star Ocean The Second Story R #Switch
+		(https://telegra.ph/file/2c7ec774526506600df7a.png)BAJONAZO FLASH a solo 47,51€, precio mínimo alcanzado incluso sin cupón (PVP 60€)
+	   ✂️ Con cupón de primera compra se te queda a solo 33,25€
+	   
+	   🌸 https://ojueg.es/vgfPa
+	   
+	   
+	   📝 Edición española con envío de lanzamiento de parte de Gamers4Life
+	   
+	   
+	   ⚪️ Si no te aclaras con el tema del cupón, averigua como sacarle partido en nuestro hilo de dudas Miravia del @GrupoNintendoOJ 
+	   🍨 https://t.me/GrupoNintendoOJ/481642
+		`,
+	}
+	goodBodyMessage, _ := json.Marshal(properMessageBody)
+
+	app.Post("/api/offers", func(context *fiber.Ctx) error {
+		return storeOffer(context, offerManager, processorService)
+	})
+
+	testCases := []struct {
+		name         string
+		route        string
+		body         string
+		expectedCode int
+	}{
+		{
+			name:         "Get HTTP status 200 when offer is stored",
+			route:        "/api/offers",
+			body:         string(goodBodyMessage),
+			expectedCode: fiber.StatusOK,
+		},
+		{
+			name:         "Get HTTP status 400 when body is not parsed",
+			route:        "/api/offers",
+			body:         `{"message": "Test Message"`,
+			expectedCode: fiber.StatusBadRequest,
+		},
+		{
+			name:         "Get HTTP status 422 when message is unprocessable",
+			route:        "/api/offers",
+			body:         `{"message": "Test Message"}`,
+			expectedCode: fiber.StatusUnprocessableEntity,
+		},
+	}
+
+	for _, testCase := range testCases {
+		request := httptest.NewRequest("POST", testCase.route, strings.NewReader(testCase.body))
+		request.Header.Set("Content-Type", "application/json")
+
+		response, _ := app.Test(request, 1)
+
+		assert.Equalf(t, testCase.expectedCode, response.StatusCode, testCase.name)
+	}
+}

--- a/src/api/go.mod
+++ b/src/api/go.mod
@@ -1,6 +1,6 @@
 module vidya-sale/api
 
-go 1.21
+go 1.20
 
 require (
 	github.com/google/uuid v1.3.1

--- a/src/api/go.mod
+++ b/src/api/go.mod
@@ -2,7 +2,16 @@ module vidya-sale/api
 
 go 1.21
 
-require github.com/google/uuid v1.3.1
+require (
+	github.com/google/uuid v1.3.1
+	github.com/stretchr/testify v1.8.4
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
 
 require (
 	github.com/andybalholm/brotli v1.0.5 // indirect

--- a/src/api/go.sum
+++ b/src/api/go.sum
@@ -1,5 +1,7 @@
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gofiber/fiber/v2 v2.49.1 h1:0W2DRWevSirc8pJl4o8r8QejDR8TV6ZUCawHxwbIdOk=
 github.com/gofiber/fiber/v2 v2.49.1/go.mod h1:nPUeEBUeeYGgwbDm59Gp7vS8MDyScL6ezr/Np9A13WU=
 github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
@@ -13,9 +15,13 @@ github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APP
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.49.0 h1:9FdvCpmxB74LH4dPb7IJ1cOSsluR07XG3I1txXWwJpE=
@@ -26,3 +32,7 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/api/service/message_processor.go
+++ b/src/api/service/message_processor.go
@@ -15,6 +15,13 @@ type MessageProcessor interface {
 
 type MessageProcessorService struct{}
 
+// NewMessageProcessorService returns a new MessageProcessorService
+func NewMessageProcessorService() *MessageProcessorService {
+	processorService := &MessageProcessorService{}
+
+	return processorService
+}
+
 // ParseMessage takes an offer message and returns the name, platform, link and price of the offer
 func (messageProcessor *MessageProcessorService) ParseMessage(message string) (string, string, string, float64) {
 	var name, platform, link string


### PR DESCRIPTION
En esta PR se pueden encontrar los cambios que añaden la capa de API de la solución. Además, se encuentran las pruebas de integración para ambos endpoints de almacenamiento de ofertas y de obtener ofertas de un videojuego en todas sus plataformas.

Esta PR cerraría las siguientes issues:

- Closes #20 